### PR TITLE
Upgraded specs2 to 5.0.0-RC-07 for Scala3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,7 @@ lazy val docs = project
 
 val disciplineV = "1.1.5"
 val specs2V = "4.12.10"
+val specs2DottyV = "5.0.0-RC-07"
 
 // General Settings
 lazy val commonSettings = Seq(
@@ -113,10 +114,7 @@ lazy val commonSettings = Seq(
   libraryDependencies += "org.typelevel" %%% "discipline-core" % disciplineV,
   libraryDependencies += {
     if (isDotty.value)
-      ("org.specs2" %%% "specs2-scalacheck" % specs2V)
-        .cross(CrossVersion.for3Use2_13)
-        .exclude("org.scalacheck", "scalacheck_2.13")
-        .exclude("org.scalacheck", "scalacheck_sjs1_2.13")
+      "org.specs2" %%% "specs2-scalacheck" % specs2DottyV
     else
       "org.specs2" %%% "specs2-scalacheck" % specs2V
   },

--- a/core/src/main/scala/org/discipline/discipline/specs2/Discipline.scala
+++ b/core/src/main/scala/org/discipline/discipline/specs2/Discipline.scala
@@ -25,10 +25,10 @@ import org.specs2.scalacheck.Parameters
 trait Discipline extends ScalaCheck { self: SpecificationLike =>
 
   def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit p: Parameters) = {
-    s"""${ruleSet.name} laws must hold for ${name}""" ^ br ^ t ^
-      Fragments.foreach(ruleSet.all.properties.toList) { case (id, prop) =>
-        id ! check(prop, p, defaultFreqMapPretty) ^ br
-      } ^ br ^ bt
+    br ^ br ^ s"""${ruleSet.name} laws must hold for ${name}""" ^ br ^ t ^
+      Fragments.foreach(ruleSet.all.properties.toList.zipWithIndex) { case ((id, prop), n) =>
+        id ! check(prop, p, defaultFreqMapPretty) ^ (if (n != ruleSet.all.properties.toList.size - 1) br else bt)
+      }
   }
 
 }

--- a/core/src/main/scala/org/discipline/discipline/specs2/mutable/Discipline.scala
+++ b/core/src/main/scala/org/discipline/discipline/specs2/mutable/Discipline.scala
@@ -27,8 +27,11 @@ trait Discipline extends ScalaCheck { self: SpecificationLike =>
   def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit p: Parameters) = {
     s"""${ruleSet.name} laws must hold for ${name}""".txt
     br
-    Fragments.foreach(ruleSet.all.properties.toList) { case (id, prop) =>
-      id in check(prop, p, defaultFreqMapPretty)
+    t
+    Fragments.foreach(ruleSet.all.properties.toList.zipWithIndex) { case ((id, prop), n) =>
+      addFragment(fragmentFactory.example(id, check(prop, p, defaultFreqMapPretty)))
+      if (n != ruleSet.all.properties.toList.size - 1) br
+      else bt
     }
   }
 


### PR DESCRIPTION
and reformatted the fragments a bit to look better when using Scala 3.

This PR prepares `discipline-specs2` for the upcoming `specs2-5.0.0` release.