### PR TITLE
Update to specs2 4.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.2, 2.12.15, 2.13.8]
+        scala: [3.1.1, 2.12.15, 2.13.8]
         java: [temurin@8]
         project: [rootJS, rootJVM]
     runs-on: ${{ matrix.os }}
@@ -147,22 +147,22 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.0.2, rootJS)
+      - name: Download target directories (3.1.1, rootJS)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.0.2-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootJS
 
-      - name: Inflate target directories (3.0.2, rootJS)
+      - name: Inflate target directories (3.1.1, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.0.2, rootJVM)
+      - name: Download target directories (3.1.1, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.0.2-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootJVM
 
-      - name: Inflate target directories (3.0.2, rootJVM)
+      - name: Inflate target directories (3.1.1, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "1.4"
+ThisBuild / tlBaseVersion := "1.5"
 
 ThisBuild / developers := List(
   tlGitHubDev("larsrh", "Lars Hupel"),
@@ -20,7 +20,7 @@ ThisBuild / tlSiteApiUrl := Some(
   url("https://www.javadoc.io/doc/org.typelevel/discipline-specs2_2.13"))
 
 val disciplineV = "1.4.0"
-val specs2V = "4.13.2"
+val specs2V = "4.14.1-cross"
 val macrotaskExecutorV = "1.0.0"
 
 lazy val root = tlCrossRootProject.aggregate(core)
@@ -30,37 +30,13 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .in(file("core"))
   .settings(
     name := "discipline-specs2",
-    libraryDependencies += "org.typelevel" %%% "discipline-core" % disciplineV,
-    Compile / doc / sources := {
-      val old = (Compile / doc / sources).value
-      if (tlIsScala3.value) Seq() else old
-    },
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "discipline-core" % disciplineV,
+      "org.specs2" %%% "specs2-scalacheck" % specs2V
+    ),
     headerLicense := Some(
       HeaderLicense.MIT(s"${startYear.value.get}-2022", organizationName.value)
     )
-  )
-  .jvmSettings(
-    libraryDependencies += {
-      if (tlIsScala3.value)
-        ("org.specs2" %%% "specs2-scalacheck" % specs2V)
-          .cross(CrossVersion.for3Use2_13)
-          .exclude("org.scalacheck", "scalacheck_2.13")
-      else
-        "org.specs2" %%% "specs2-scalacheck" % specs2V
-    }
-  )
-  .jsSettings(
-    tlVersionIntroduced ~= { _ ++ List("2.12", "2.13").map(_ -> "1.1.0").toMap },
-    libraryDependencies += {
-      if (tlIsScala3.value)
-        ("org.specs2" %%% "specs2-scalacheck" % specs2V)
-          .cross(CrossVersion.for3Use2_13)
-          .exclude("org.scalacheck", "scalacheck_sjs1_2.13")
-          .exclude("org.scala-js", "scala-js-macrotask-executor_sjs1_2.13")
-      else
-        "org.specs2" %%% "specs2-scalacheck" % specs2V
-    },
-    libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % macrotaskExecutorV
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin).dependsOn(core.jvm)

--- a/build.sbt
+++ b/build.sbt
@@ -38,5 +38,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       HeaderLicense.MIT(s"${startYear.value.get}-2022", organizationName.value)
     )
   )
+  .jsSettings(
+    tlVersionIntroduced ~= { _ ++ List("2.12", "2.13").map(_ -> "1.1.0").toMap }
+  )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin).dependsOn(core.jvm)

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ ThisBuild / developers := List(
 val Scala213 = "2.13.8"
 
 ThisBuild / tlCiReleaseTags := false
-ThisBuild / crossScalaVersions := Seq("3.0.2", "2.12.15", Scala213)
+ThisBuild / crossScalaVersions := Seq("3.1.1", "2.12.15", Scala213)
 ThisBuild / tlVersionIntroduced := Map("3" -> "1.1.6")
 
 ThisBuild / licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / tlSiteApiUrl := Some(
   url("https://www.javadoc.io/doc/org.typelevel/discipline-specs2_2.13"))
 
 val disciplineV = "1.4.0"
-val specs2V = "4.14.1-cross"
+val specs2V = "4.15.0"
 val macrotaskExecutorV = "1.0.0"
 
 lazy val root = tlCrossRootProject.aggregate(core)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.9.0")
 val sbtTypelevelVersion = "0.4.6"
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTypelevelVersion)


### PR DESCRIPTION
We now have specs2 4.15.0 which is published for all 3 scalas! 🎉 

So ... the only project it leaves in an awkward place is discipline-specs2 itself. This project previously published Scala 3 artifacts depending on specs2 with `for3use2_13`, so it's technically a breaking change to swap that out now for the real Scala 3 artifacts. But, maybe we should just bump the minor and swallow it?