### PR TITLE
Fixing the native build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     tlVersionIntroduced ~= { _ ++ List("2.12", "2.13").map(_ -> "1.1.0").toMap }
   )
   .nativeSettings(
-    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.4.0").toMap
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.5.0").toMap
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin).dependsOn(core.jvm)

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ ThisBuild / startYear := Some(2019)
 ThisBuild / tlSiteApiUrl := Some(
   url("https://www.javadoc.io/doc/org.typelevel/discipline-specs2_2.13"))
 
-val disciplineV = "1.6.0"
-val specs2V = "4.20.5"
+val disciplineV = "1.7.0"
+val specs2V = "4.20.7"
 
 lazy val root = tlCrossRootProject.aggregate(core)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ val sbtTypelevelVersion = "0.7.1"
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTypelevelVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.3")


### PR DESCRIPTION
This should fix the build now that [specs2 is correctly published](https://github.com/etorreborre/specs2/issues/1248)

@armanbilge I'm tagging you to ask for a confirmation that setting tlVersionIntroduced to next version for native is the correct way to fix the build given that the artifact name changed (and the bin compat checks should be reset).